### PR TITLE
modified script to pass --worktree-attributes to archive commands

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -101,7 +101,6 @@ TMPDIR=${TMPDIR:-/tmp}
 TMPFILE=`mktemp "$TMPDIR/$PROGRAM.XXXXXX"` # Create a place to store our work's progress
 TOARCHIVE=`mktemp "$TMPDIR/$PROGRAM.toarchive.XXXXXX"`
 OUT_FILE=$OLD_PWD # assume "this directory" without a name change by default
-WORKTREE_ATTRIBUTES=0
 SEPARATE=0
 
 FORMAT=tar
@@ -129,8 +128,8 @@ while test $# -gt 0; do
             ;;
 
         --worktree-attributes )
+            ARCHIVE_OPTS+=" $1"
             shift
-            WORKTREE_ATTRIBUTES=1
             ;;
 
         --separate | -s )
@@ -173,10 +172,6 @@ if [ $SEPARATE -eq 1 -a ! -d $OUT_FILE ]; then
 elif [ `git config -l | grep -q '^core\.bare=false'; echo $?` -ne 0 ]; then
     echo "$PROGRAM must be run from a git working copy (i.e., not a bare repository)."
     exit
-fi
-
-if [ $WORKTREE_ATTRIBUTES -eq 1 ]; then
-    ARCHIVE_OPTS=--worktree-attributes
 fi
 
 # Create the superproject's git-archive

--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -45,7 +45,7 @@ trap 'cleanup' QUIT EXIT
 # to newline, space, tab
 OLD_IFS=$IFS
 IFS='
- 	'
+    '
 
 function cleanup () {
     rm -f $TMPFILE
@@ -62,7 +62,7 @@ function usage () {
     echo "$PROGRAM <--usage|--help|-?>"
     echo "    Prints this usage output and exits."
     echo
-    echo "$PROGRAM [--format <fmt>] [--prefix <path>] [--separate|-s] [output_file]"
+    echo "$PROGRAM [--format <fmt>] [--prefix <path>] [--worktree-attributes] [--separate|-s] [output_file]"
     echo "    Creates an archive for the entire git superproject, and its submodules"
     echo "    using the passed parameters, described below."
     echo
@@ -72,6 +72,9 @@ function usage () {
     echo
     echo "    If '--prefix' is specified, the archive's superproject and all submodules"
     echo "    are created with the <path> prefix named. The default is to not use one."
+    echo
+    echo "    If '--worktree-attributes' is specified, the invidual archive commands will"
+    echo "    look for attributes in .gitattributes in the working directory too."
     echo
     echo "    If '--separate' or '-s' is specified, individual archives will be created"
     echo "    for each of the superproject itself and its submodules. The default is to"
@@ -98,11 +101,13 @@ TMPDIR=${TMPDIR:-/tmp}
 TMPFILE=`mktemp "$TMPDIR/$PROGRAM.XXXXXX"` # Create a place to store our work's progress
 TOARCHIVE=`mktemp "$TMPDIR/$PROGRAM.toarchive.XXXXXX"`
 OUT_FILE=$OLD_PWD # assume "this directory" without a name change by default
+WORKTREE_ATTRIBUTES=0
 SEPARATE=0
 
 FORMAT=tar
 PREFIX=
 TREEISH=HEAD
+ARCHIVE_OPTS=
 
 # RETURN VALUES/EXIT STATUS CODES
 readonly E_BAD_OPTION=254
@@ -121,6 +126,11 @@ while test $# -gt 0; do
             shift
             PREFIX="$1"
             shift
+            ;;
+
+        --worktree-attributes )
+            shift
+            WORKTREE_ATTRIBUTES=1
             ;;
 
         --separate | -s )
@@ -165,8 +175,12 @@ elif [ `git config -l | grep -q '^core\.bare=false'; echo $?` -ne 0 ]; then
     exit
 fi
 
+if [ $WORKTREE_ATTRIBUTES -eq 1 ]; then
+    ARCHIVE_OPTS=--worktree-attributes
+fi
+
 # Create the superproject's git-archive
-git-archive --format=$FORMAT --prefix="$PREFIX" $TREEISH > $TMPDIR/$(basename $(pwd)).$FORMAT
+git-archive --format=$FORMAT --prefix="$PREFIX" $ARCHIVE_OPTS $TREEISH > $TMPDIR/$(basename $(pwd)).$FORMAT
 echo $TMPDIR/$(basename $(pwd)).$FORMAT >| $TMPFILE # clobber on purpose
 superfile=`head -n 1 $TMPFILE`
 
@@ -176,7 +190,7 @@ find . -name '.git' -type d -print | sed -e 's/^\.\///' -e 's/\.git$//' | grep -
 while read path; do
     TREEISH=$(git-submodule | grep "^ .*${path%/} " | cut -d ' ' -f 2) # git-submodule does not list trailing slashes in $path
     cd "$path"
-    git-archive --format=$FORMAT --prefix="${PREFIX}$path" ${TREEISH:-HEAD} > "$TMPDIR"/"$(echo "$path" | sed -e 's/\//./g')"$FORMAT
+    git-archive --format=$FORMAT --prefix="${PREFIX}$path" $ARCHIVE_OPTS ${TREEISH:-HEAD} > "$TMPDIR"/"$(echo "$path" | sed -e 's/\//./g')"$FORMAT
     if [ $FORMAT == 'zip' ]; then
         # delete the empty directory entry; zipped submodules won't unzip if we don't do this
         zip -d "$(tail -n 1 $TMPFILE)" "${PREFIX}${path%/}" >/dev/null # remove trailing '/'
@@ -206,3 +220,4 @@ fi
 while read file; do
     mv "$file" "$OUT_FILE"
 done < $TMPFILE
+

--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -44,8 +44,7 @@ trap 'cleanup' QUIT EXIT
 # For security reasons, explicitly set the internal field separator
 # to newline, space, tab
 OLD_IFS=$IFS
-IFS='
-    '
+IFS="\n \t"
 
 function cleanup () {
     rm -f $TMPFILE


### PR DESCRIPTION
A `.gitattributes` file can be used (amongst other things) to set certain files to be ignored for an export. `git archive` takes the option `--worktree-attributes` to respect this file. This change adds the option to `git archive-all` too.