### PR TITLE
support for osx

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -103,6 +103,8 @@ OUT_FILE=$OLD_PWD # assume "this directory" without a name change by default
 SEPARATE=0
 VERBOSE=0
 
+TARCMD=tar
+[[ $(uname) == "Darwin" ]] && TARCMD=gnutar
 FORMAT=tar
 PREFIX=
 TREEISH=HEAD
@@ -227,7 +229,7 @@ fi
 if [ $SEPARATE -eq 0 ]; then
     if [ $FORMAT == 'tar' ]; then
         sed -e '1d' $TMPFILE | while read file; do
-            tar --concatenate -f "$superfile" "$file" && rm -f "$file"
+            $TARCMD --concatenate -f "$superfile" "$file" && rm -f "$file"
         done
     elif [ $FORMAT == 'zip' ]; then
         sed -e '1d' $TMPFILE | while read file; do


### PR DESCRIPTION
stock osx comes with old bsd utils so /usr/bin/tar doesn't accept the
--concatenate option. luckily though stock osx comes with
/usr/bin/gnutar which is pretty much the same version as the gnu/linux
tar which accepts the --concatenate option.

if we're on osx (ie uname => Darwin) use gnutar rather than tar.
