### PR TITLE
Fix basename 'too many arguments' error

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -179,11 +179,11 @@ fi
 if [ $VERBOSE -eq 1 ]; then
     echo -n "creating superproject archive..."
 fi
-git archive --format=$FORMAT --prefix="$PREFIX" $TREEISH > $TMPDIR/$(basename $(pwd)).$FORMAT
+git archive --format=$FORMAT --prefix="$PREFIX" $TREEISH > $TMPDIR/$(basename "$(pwd)").$FORMAT
 if [ $VERBOSE -eq 1 ]; then
     echo "done"
 fi
-echo $TMPDIR/$(basename $(pwd)).$FORMAT >| $TMPFILE # clobber on purpose
+echo $TMPDIR/$(basename "$(pwd)").$FORMAT >| $TMPFILE # clobber on purpose
 superfile=`head -n 1 $TMPFILE`
 
 if [ $VERBOSE -eq 1 ]; then


### PR DESCRIPTION
Error above arises when current working directory path contains any spaces. (as in my example: '~/Documents/Local Git Repositories/...')
Putting variable in quotes to eliminate this problem.
