### PR TITLE
Fix license inaccuracy (GPL2). MERGE ONLY ONE

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -14,7 +14,7 @@
 #
 #              where $GIT_DIR is the root of your git superproject.
 #
-# License:     GPL3
+# License:     GPL2+
 #
 ###############################################################################
 #


### PR DESCRIPTION
The license text disagrees with the "License:" header. This PR resolves this disagreement towards being a "GPL2+" license. (Note: This is not a change, as the license text already says "or (at your option) any later version.")

Please only merge this XOR my other pull request: #27 