### PR TITLE
Fix license inaccuracy (GPL3). MERGE ONLY ONE

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -14,13 +14,13 @@
 #
 #              where $GIT_DIR is the root of your git superproject.
 #
-# License:     GPL3
+# License:     GPL3+
 #
 ###############################################################################
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
The license text disagrees with the "License:" header. This PR resolves this disagreement towards being a "GPL3+" license. (Note: This is not a change, as the license text already says "or (at your option) any later version.")

Please only merge this XOR my other pull request: #26