### PR TITLE
Set $IFS using printf

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -44,7 +44,7 @@ trap 'cleanup' QUIT EXIT
 # For security reasons, explicitly set the internal field separator
 # to newline, space, tab
 OLD_IFS=$IFS
-IFS="\n \t"
+IFS="$(printf '\n \t')"
 
 function cleanup () {
     rm -f $TMPFILE


### PR DESCRIPTION
The existing line of code makes bash to treat `n` and `t` as separator,
which cause `echo $TARCMD` to print `/usr/bi / tar`.