### PR TITLE
Older version of git do not add core.bare=false

### DIFF
--- a/git-archive-all.sh
+++ b/git-archive-all.sh
@@ -209,7 +209,7 @@ elif [ $SEPARATE -eq 1 -a ! -d "$OUT_FILE" ]; then
     echo "When creating multiple archives, your destination must be a directory."
     echo "If it's not, you risk being surprised when your files are overwritten."
     exit
-elif [ `git config -l | grep -q '^core\.bare=false'; echo $?` -ne 0 ]; then
+elif [ `git config -l | grep -q '^core\.bare=true'; echo $?` -eq 0 ]; then
     echo "$PROGRAM must be run from a git working copy (i.e., not a bare repository)."
     exit
 fi


### PR DESCRIPTION
git version 1.7.11.3 does not have core.bare=false by default so
change the test to look for core.bare=true instead as it is there
in older and newer versions of git.

	modified:   git-archive-all.sh